### PR TITLE
File Preview Time For Videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ filepreview depends on 'ImageMagick':
   $ apt-get install imagemagick
 ```
 
+
+filepreview depends on 'curl':
+
+```
+  $ apt-get install curl
+```
+
 To install use npm:
 
 ```
@@ -62,15 +69,19 @@ Synchronous (if error, will return false):
 
 ```
 
+You can specify a url instead of a file path, ie: http://www.myfile.com/my_file.doc, and filepreview will download it and generate a its preview.
+
 You can set options object for the preview generation. List of options available:-
 * width
 * height
+* quality [see quality documentation](https://www.imagemagick.org/script/command-line-options.php#quality)
 
 e.g.
 ```javascript
 var options = {
   width: 640,
-  height: 480
+  height: 480,
+  quality: 90
 };
 
 // Asynchronous

--- a/README.md
+++ b/README.md
@@ -75,13 +75,23 @@ You can set options object for the preview generation. List of options available
 * width
 * height
 * quality [see quality documentation](https://www.imagemagick.org/script/command-line-options.php#quality)
+* previewTime
 
-e.g.
+e.g. Document/Image
 ```javascript
 var options = {
   width: 640,
   height: 480,
   quality: 90
+};
+
+e.g. Video
+```javascript
+var options = {
+  width: 640,
+  height: 480,
+  quality: 90,
+  previewTime: '00:03:00.000'
 };
 
 // Asynchronous

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Synchronous (if error, will return false):
 
 ```
 
-You can specify a url instead of a file path, ie: http://www.myfile.com/my_file.doc, and filepreview will download it and generate a its preview.
+You can specify a url instead of a file path, ie: http://www.myfile.com/my_file.doc, and filepreview will download it to generate its preview.
 
 You can set options object for the preview generation. List of options available:-
 * width

--- a/filepreview.js
+++ b/filepreview.js
@@ -100,7 +100,7 @@ module.exports = {
             convertArgs.splice(0, 0, '-resize', options.width + 'x' + options.height);
           }
           if (options.quality) {
-            convertOtherArgs.splice(0, 0, '-quality', options.quality);
+            convertArgs.splice(0, 0, '-quality', options.quality);
           }
           child_process.execFile('convert', convertArgs, function(error) {
             if (input_original.indexOf("http://") == 0 || input_original.indexOf("https://") == 0) {
@@ -231,7 +231,7 @@ module.exports = {
           convertArgs.splice(0, 0, '-resize', options.width + 'x' + options.height);
         }
         if (options.quality) {
-          convertOtherArgs.splice(0, 0, '-quality', options.quality);
+          convertArgs.splice(0, 0, '-quality', options.quality);
         }
         child_process.execFileSync('convert', convertArgs);
         if (input_original.indexOf("http://") == 0 || input_original.indexOf("https://") == 0) {

--- a/filepreview.js
+++ b/filepreview.js
@@ -10,7 +10,7 @@ var path = require('path');
 var fs = require('fs');
 var os = require('os');
 var mimedb = require('./db.json');
-var http = require('http');
+var download = require('download-file')
 
 module.exports = {
   generate: function(input, output, options, callback) {
@@ -59,7 +59,7 @@ module.exports = {
     if ( extInput == 'pdf' ) {
       fileType = 'image';
     }
-
+    /*
     if (input.indexOf("http://") == 0 || input.indexOf("https://") == 0) {
       var url = input.split("/");
       var url_filename = url[url.length - 1];
@@ -74,6 +74,7 @@ module.exports = {
       file = request.data;
       input = temp_input;
     }
+    */
 
     fs.lstat(input, function(error, stats) {
       if (error) return callback(error);

--- a/filepreview.js
+++ b/filepreview.js
@@ -80,10 +80,16 @@ module.exports = {
         return callback(true);
       } else {
         if ( fileType == 'video' ) {
-          var ffmpegArgs = ['-y', '-i', input, '-vf', 'thumbnail', '-frames:v', '1', output];
+          var ffmpegArgs = ['-y', '-i', input, '-vf', 'thumbnail', '-frames:v', '1'];
           if (options.width > 0 && options.height > 0) {
             ffmpegArgs.splice(4, 1, 'thumbnail,scale=' + options.width + ':' + options.height);
           }
+          if (options.hasOwnProperty('previewTime')) {
+            ffmpegArgs.push("-ss");
+            ffmpegArgs.push(options.previewTime)
+          }
+          ffmpegArgs.push(output);
+
           child_process.execFile('ffmpeg', ffmpegArgs, function(error) {
             if (input_original.indexOf("http://") == 0 || input_original.indexOf("https://") == 0) {
               fs.unlinkSync(input);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filepreview",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "A file preview generator for node.js",
   "main": "filepreview.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filepreview",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "A file preview generator for node.js",
   "main": "filepreview.js",
   "scripts": {
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/maxlabelle/filepreview/issues"
   },
-  "homepage": "https://github.com/maxlabelle/filepreview#readme"
+  "homepage": "https://github.com/maxlabelle/filepreview#readme",
+  "dependencies": {
+    "synchronize": "^2.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/maxlabelle/filepreview#readme",
   "dependencies": {
+    "download-file": "^0.1.5",
     "synchronize": "^2.0.0"
   }
 }


### PR DESCRIPTION
This node module originally only took the screenshot for the first few seconds of the video/movie. This is an issue because for most movies the first few seconds are black and the first few minutes are simple the introduction.

![beforefilepreview](https://user-images.githubusercontent.com/13894625/52526312-b675f600-2c84-11e9-8eda-1d3099d7b93e.png)

I updated the options configuration to have the option to specify when the preview is generated for videos. If the user passes in nothing for previewTime, this behaves as it did before. 

```
var options = {
    width: 200,
    quality: 50,
    previewTime: '00:10:30.000'
};
```

### Final results:

![afterfilepreview](https://user-images.githubusercontent.com/13894625/52526317-cd1c4d00-2c84-11e9-8a28-8e3693f3cd07.png)

A review of this would be greatly appreciated. 

